### PR TITLE
Add new pipeline tests, update copyright dates, A+ on goreportcard.com

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,5 @@ keys/
 # Packr files and directories
 packrd/
 main-packr.go
+pkg/chefutils/chefutils-packr.go
 params.go

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+Copyright 2020 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
 Under the terms of Contract DE-NA0003525 with NTESS, 
 the U.S. Government retains certain rights in this software.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License](http://img.shields.io/:license-mit-blue.svg)](https://github.com/master-of-servers/MOSE/blob/master/LICENSE)
 [![Build Status](https://dev.azure.com/jaysonegrace/MOSE/_apis/build/status/master-of-servers.MOSE?branchName=master)](https://dev.azure.com/jaysonegrace/MOSE/_build/latest?definitionId=5&branchName=master)
 
-> Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+> Copyright 2020 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
 Under the terms of Contract DE-NA0003525 with NTESS, 
 the U.S. Government retains certain rights in this software
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,11 +65,39 @@ steps:
   workingDirectory: "$(modulePath)"
 
 - script: | 
+    # Copy MOSE payload to puppet master
     docker cp $(modulePath)/payloads/puppet-linux basic-puppetmaster:/puppet-linux
+
+    # Run MOSE against the puppet master
     docker exec -i basic-puppetmaster /bin/bash -c "echo 'Y' | /puppet-linux"
+    # Run puppet agent -t to enact the changes made by MOSE
     docker exec -i basic-puppetagent /bin/bash -c "puppet agent -t"
+
+    # Ensure that MOSE is working properly by running cat on the file it created
     docker exec -i basic-puppetagent /bin/bash -c "cat /tmp/test.txt"
   displayName: 'Run MOSE generated payload on puppet test environment'
+  workingDirectory: "$(modulePath)"
+
+- script: |
+    echo 'echo testing file upload > /tmp/file_upload_test.txt' > payloads/notevil.sh
+    export GO111MODULE=on
+    ./mose -fu ${PWD}/payloads/notevil.sh -t puppet -f ${PWD}/payloads/puppet-linux
+  displayName: 'Generate a puppet payload to test file upload'
+  workingDirectory: "$(modulePath)"
+
+- script: | 
+    # Copy MOSE payload to puppet master
+    docker cp $(modulePath)/payloads/files.tar basic-puppetmaster:/files.tar
+    
+    # Run MOSE against the puppet master
+    docker exec -i basic-puppetmaster /bin/bash -c "tar -xvf files.tar"
+    docker exec -i basic-puppetmaster /bin/bash -c "echo 'Y' | /puppet-linux"
+    # Run puppet agent -t to enact the changes made by MOSE
+    docker exec -i basic-puppetagent /bin/bash -c "puppet agent -t"
+    
+    # Ensure that MOSE is working properly by running cat on the file it created
+    docker exec -i basic-puppetagent /bin/bash -c "cat /tmp/file_upload_test.txt"
+  displayName: 'Run MOSE generated file upload payload on puppet test environment'
   workingDirectory: "$(modulePath)"
 # End Puppet
 
@@ -115,6 +143,28 @@ steps:
     # Ensure that MOSE is working properly by running cat on the file it created
     docker exec -i basic-chef-agent-1 /bin/bash -c "cat /tmp/test.txt"
   displayName: 'Run MOSE generated payload on workstation in chef test environment'
+  workingDirectory: "$(modulePath)"
+
+- script: |
+    echo 'echo testing file upload > /tmp/file_upload_test.txt' > payloads/notevil.sh
+    export GO111MODULE=on
+    expect scripts/test_chef_workstation_file_upload.exp
+  displayName: 'Generate a chef payload to test file upload'
+  workingDirectory: "$(modulePath)"
+
+- script: | 
+    # Copy MOSE payload to workstation
+    docker cp $(modulePath)/payloads/files.tar basic-chef-workstation:/files.tar
+    
+    # Run MOSE against the workstation
+    docker exec -i basic-chef-workstation /bin/bash -c "tar -xvf files.tar"
+    docker exec -i basic-chef-workstation /bin/bash -c "echo 'n' | /chef-linux"
+    # Run chef-client to enact the changes made by MOSE
+    docker exec -i basic-chef-agent-1 /bin/bash -c "chef-client"
+    
+    # Ensure that MOSE is working properly by running cat on the file it created
+    docker exec -i basic-chef-agent-1 /bin/bash -c "cat /tmp/file_upload_test.txt"
+  displayName: 'Run MOSE generated file upload payload on workstation in chef test environment'
   workingDirectory: "$(modulePath)"
 # End Chef
 

--- a/cmd/mose/chef/main.go
+++ b/cmd/mose/chef/main.go
@@ -1,4 +1,4 @@
-// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+// Copyright 2020 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 
@@ -24,11 +24,12 @@ import (
 	"time"
 
 	"github.com/gobuffalo/packr/v2"
+	utils "github.com/l50/goutils"
 	"github.com/master-of-servers/mose/pkg/chefutils"
 	"github.com/master-of-servers/mose/pkg/moseutils"
-	utils "github.com/l50/goutils"
 )
 
+// Command holds information used to run commands on a target chef system
 type Command struct {
 	CmdName  string
 	Cmd      string
@@ -36,6 +37,7 @@ type Command struct {
 	FilePath string
 }
 
+// Metadata holds the payload name to run on a target chef system
 type Metadata struct {
 	PayloadName string
 }
@@ -536,7 +538,7 @@ func main() {
 		uploadFileName = suppliedFilename
 	}
 	// check if knife binary exists on server
-	found, knifeFile := moseutils.FindBin("knife", []string{"/bin", "/home", "/opt", "/root"})
+	found, knifeFile := moseutils.FindFile("knife", []string{"/bin", "/home", "/opt", "/root"})
 
 	if found {
 		if cleanup {
@@ -546,7 +548,7 @@ func main() {
 	}
 
 	moseutils.Info("Determining if we are on a chef server or an invalid target, please wait...")
-	found, chefServerFile := moseutils.FindBin("chef-server-ctl", []string{"/bin", "/home", "/opt", "/root"})
+	found, chefServerFile := moseutils.FindFile("chef-server-ctl", []string{"/bin", "/home", "/opt", "/root"})
 	if found {
 		chefServer(chefServerFile, chefFiles)
 	}

--- a/cmd/mose/puppet/export_test.go
+++ b/cmd/mose/puppet/export_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+// Copyright 2020 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software
 

--- a/cmd/mose/puppet/main.go
+++ b/cmd/mose/puppet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+// Copyright 2020 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 
@@ -274,7 +274,7 @@ func getSecretKeys() map[string]*eyamlKeys {
 
 func findHieraSecrets() {
 	// Detect if the eyaml binary exists
-	exists, eyamlFile := moseutils.FindBin("eyaml", []string{"/bin", "/home", "/opt", "/root", "/usr"})
+	exists, eyamlFile := moseutils.FindFile("eyaml", []string{"/bin", "/home", "/opt", "/root", "/usr"})
 	if !exists {
 		log.Printf("Eyaml not found, no need to find secrets")
 		return

--- a/cmd/mose/puppet/main_test.go
+++ b/cmd/mose/puppet/main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+// Copyright 2020 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software
 

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/rogpeppe/go-internal v1.5.1 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	golang.org/x/crypto v0.0.0-20191227163750-53104e6ec876 // indirect
-	golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8 // indirect
+	golang.org/x/sys v0.0.0-20200102141924-c96a22e43c9c // indirect
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
 	google.golang.org/grpc v1.21.1 // indirect
 	gopkg.in/src-d/go-git.v4 v4.12.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -196,8 +196,8 @@ golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190515120540-06a5c4944438 h1:khxRGsvPk4n2y8I/mLLjp7e5dMTJmH75wvqS6nMwUtY=
 golang.org/x/sys v0.0.0-20190515120540-06a5c4944438/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8 h1:JA8d3MPx/IToSyXZG/RhwYEtfrKO1Fxrqe8KrkiLXKM=
-golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200102141924-c96a22e43c9c h1:OYFUffxXPezb7BVTx9AaD4Vl0qtxmklBIkwCKH1YwDY=
+golang.org/x/sys v0.0.0-20200102141924-c96a22e43c9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 h1:SvFZT6jyqRaOeXpc5h/JSfZenJ2O330aBsf7JfSUXmQ=

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+// Copyright 2020 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 
@@ -16,9 +16,9 @@ import (
 	"time"
 
 	"github.com/gobuffalo/packr/v2"
+	utils "github.com/l50/goutils"
 	"github.com/master-of-servers/mose/pkg/chefutils"
 	"github.com/master-of-servers/mose/pkg/moseutils"
-	utils "github.com/l50/goutils"
 )
 
 var (

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1,4 +1,4 @@
-// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+// Copyright 2020 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 

--- a/pkg/chefutils/agentutils.go
+++ b/pkg/chefutils/agentutils.go
@@ -1,4 +1,4 @@
-// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+// Copyright 2020 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 

--- a/pkg/chefutils/container.go
+++ b/pkg/chefutils/container.go
@@ -1,4 +1,4 @@
-// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+// Copyright 2020 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 

--- a/pkg/chefutils/filehandler.go
+++ b/pkg/chefutils/filehandler.go
@@ -1,4 +1,4 @@
-// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+// Copyright 2020 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 

--- a/pkg/moseutils/cli.go
+++ b/pkg/moseutils/cli.go
@@ -1,4 +1,4 @@
-// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+// Copyright 2020 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 
@@ -66,6 +66,7 @@ func usage() {
 	os.Exit(1)
 }
 
+// ParseCLIArgs parses all specified command line arguments
 func ParseCLIArgs() CliArgs {
 	setFlags()
 	CliArgs := CliArgs{

--- a/pkg/moseutils/fileutils.go
+++ b/pkg/moseutils/fileutils.go
@@ -1,4 +1,4 @@
-// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+// Copyright 2020 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 
@@ -19,6 +19,9 @@ import (
 	"github.com/mholt/archiver"
 )
 
+// CreateFolders creates folders specified in an input slice (folders)
+// It returns true if it is able to create all of the folders
+// Otherwise it returns false
 func CreateFolders(folders []string) bool {
 	for _, f := range folders {
 		err := os.MkdirAll(f, os.ModePerm)
@@ -31,6 +34,8 @@ func CreateFolders(folders []string) bool {
 	return true
 }
 
+// FileExists returns true if a file input (fileLoc) exists on the filesystem
+// Otherwise it returns false
 func FileExists(fileLoc string) bool {
 	if _, err := os.Stat(fileLoc); err == nil {
 		return true
@@ -38,6 +43,8 @@ func FileExists(fileLoc string) bool {
 	return false
 }
 
+// GrepFile looks for patterns in a file (filePath) using an input regex (regex)
+// It will return any matches that are found in the file in a slice
 func GrepFile(filePath string, regex *regexp.Regexp) []string {
 	file, err := ioutil.ReadFile(filePath)
 
@@ -49,6 +56,8 @@ func GrepFile(filePath string, regex *regexp.Regexp) []string {
 	return matches
 }
 
+// GetFileAndDirList gets all of the files and directories specified the initial search location (searchDirs)
+// It returns a list of files and a list of directories found
 func GetFileAndDirList(searchDirs []string) ([]string, []string) {
 	fileList := []string{}
 	dirList := []string{}
@@ -70,6 +79,8 @@ func GetFileAndDirList(searchDirs []string) ([]string, []string) {
 	return fileList, dirList
 }
 
+// File2lines returns a slice that contains all of the lines of the file specified with filePath
+// Resource: https://siongui.github.io/2017/01/30/go-insert-line-or-string-to-file/
 func File2lines(filePath string) ([]string, error) {
 	f, err := os.Open(filePath)
 	if err != nil {
@@ -79,6 +90,8 @@ func File2lines(filePath string) ([]string, error) {
 	return LinesFromReader(f)
 }
 
+// InsertStringToFile with insert a string (str) into the n-th line (index) of a specified file (path)
+// Resource: https://siongui.github.io/2017/01/30/go-insert-line-or-string-to-file/
 func InsertStringToFile(path, str string, index int) error {
 	lines, err := File2lines(path)
 	if err != nil {
@@ -97,6 +110,8 @@ func InsertStringToFile(path, str string, index int) error {
 	return ioutil.WriteFile(path, []byte(fileContent), 0644)
 }
 
+// LinesFromReader will return the lines read from a reader
+// Resource: https://siongui.github.io/2017/01/30/go-insert-line-or-string-to-file/
 func LinesFromReader(r io.Reader) ([]string, error) {
 	var lines []string
 	scanner := bufio.NewScanner(r)
@@ -110,6 +125,7 @@ func LinesFromReader(r io.Reader) ([]string, error) {
 	return lines, nil
 }
 
+// TarFiles will create a tar file at a specific location (tarLocation) with the files specified (files)
 func TarFiles(files []string, tarLocation string) {
 	tar := archiver.Tar{
 		OverwriteExisting: true,
@@ -120,6 +136,9 @@ func TarFiles(files []string, tarLocation string) {
 	}
 }
 
+// ReplLineInFile will replace a line in a file (filePath) with the specified replStr and delimiter (delim)
+// It will return true with the path to the file if successful
+// Otherwise it will return false and an empty string
 func ReplLineInFile(filePath string, delim string, replStr string) (bool, string) {
 	input, err := ioutil.ReadFile(filePath)
 	if err != nil {
@@ -143,6 +162,7 @@ func ReplLineInFile(filePath string, delim string, replStr string) (bool, string
 	return true, filePath
 }
 
+// TrackChanges is used to track changes in a file
 func TrackChanges(filePath string, content string) (bool, error) {
 	f, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
@@ -158,6 +178,7 @@ func TrackChanges(filePath string, content string) (bool, error) {
 	return true, nil
 }
 
+// RemoveTracker removes a file created with TrackChanges
 func RemoveTracker(filePath string, osTarget string, destroy bool) {
 	f, err := os.Open(filePath)
 	if err != nil {

--- a/pkg/moseutils/messages.go
+++ b/pkg/moseutils/messages.go
@@ -1,4 +1,4 @@
-// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+// Copyright 2020 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 
@@ -9,8 +9,10 @@ import (
 )
 
 var (
-	// Colorized output
+	// ErrMsg outputs red text to signify an error
 	ErrMsg = color.Red
-	Info   = color.Yellow
-	Msg    = color.Green
+	// Info outputs yellow text to signify an informational message
+	Info = color.Yellow
+	// Msg outputs green text to signify success
+	Msg = color.Green
 )

--- a/pkg/moseutils/netutils.go
+++ b/pkg/moseutils/netutils.go
@@ -1,4 +1,4 @@
-// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+// Copyright 2020 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 
@@ -18,6 +18,7 @@ var (
 	fileUploaded chan bool
 )
 
+// GetHostname returns the hostname of the local system
 func GetHostname() string {
 	name, err := os.Hostname()
 	if err != nil {
@@ -26,6 +27,7 @@ func GetHostname() string {
 	return name
 }
 
+// GetLocalIP returns the IP address of the local system
 func GetLocalIP() (string, error) {
 	ifaces, err := net.Interfaces()
 	if err != nil {
@@ -73,6 +75,7 @@ func singleFile(h http.Handler) http.Handler {
 	})
 }
 
+// StartServer stands up a web server that can be used to serve files
 func StartServer(port int, webDir string, ssl bool, cert string, key string, waitTime time.Duration, singleServe bool) *http.Server {
 	fileUploaded = make(chan bool)
 	srv := &http.Server{Addr: ":" + strconv.Itoa(port)}

--- a/pkg/moseutils/settings.go
+++ b/pkg/moseutils/settings.go
@@ -1,4 +1,4 @@
-// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+// Copyright 2020 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 

--- a/pkg/moseutils/sliceutils.go
+++ b/pkg/moseutils/sliceutils.go
@@ -1,9 +1,11 @@
-// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+// Copyright 2020 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 
 package moseutils
 
+// SliceUniqMap is an idiomatic way to remove duplicates in a slice
+// Resource: https://www.reddit.com/r/golang/comments/5ia523/idiomatic_way_to_remove_duplicates_in_a_slice/
 func SliceUniqMap(s []string) []string {
 	seen := make(map[string]struct{}, len(s))
 	j := 0
@@ -18,6 +20,7 @@ func SliceUniqMap(s []string) []string {
 	return s[:j]
 }
 
+// StringInSlice can be used to determine if a string exists in a slice
 func StringInSlice(a string, list []string) bool {
 	for _, b := range list {
 		if b == a {

--- a/pkg/moseutils/sysutils.go
+++ b/pkg/moseutils/sysutils.go
@@ -1,4 +1,4 @@
-// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+// Copyright 2020 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 
@@ -12,6 +12,7 @@ import (
 	"strings"
 )
 
+// CpFile is used to copy a file from a source (src) to a destination (dst)
 func CpFile(src string, dst string) {
 	input, err := ioutil.ReadFile(src)
 	if err != nil {
@@ -26,6 +27,7 @@ func CpFile(src string, dst string) {
 	}
 }
 
+// Cd changes the directory to the one specified with dir
 func Cd(dir string) {
 	err := os.Chdir(dir)
 	if err != nil {
@@ -99,13 +101,16 @@ func FindFiles(locations []string, extensionList []string, fileNames []string, d
 	return foundFileKeys, foundDirsKeys
 }
 
-func FindBin(binName string, dirs []string) (bool, string) {
+// FindFile locates a file (fileName) in a list of input directories (dir)
+// If the file is found, then it returns true along with the file location
+// Otherwise it returns false with an empty string
+func FindFile(fileName string, dirs []string) (bool, string) {
 	fileList, _ := GetFileAndDirList(dirs)
 	for _, file := range fileList {
-		fileReg := `\b` + binName + `$\b`
+		fileReg := `\b` + fileName + `$\b`
 		m, err := regexp.MatchString(fileReg, file)
 		if err != nil {
-			log.Fatalf("We had an issue locating the %v binary: %v\n", fileReg, err)
+			log.Fatalf("We had an issue locating the %v file: %v\n", fileReg, err)
 		} else {
 			if m {
 				return true, file

--- a/pkg/moseutils/ui.go
+++ b/pkg/moseutils/ui.go
@@ -1,4 +1,4 @@
-// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+// Copyright 2020 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 

--- a/pkg/moseutils/userinput.go
+++ b/pkg/moseutils/userinput.go
@@ -1,4 +1,4 @@
-// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+// Copyright 2020 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 

--- a/scripts/test_chef_workstation_file_upload.exp
+++ b/scripts/test_chef_workstation_file_upload.exp
@@ -1,0 +1,7 @@
+#!/usr/bin/expect -f
+
+spawn ./mose -fu "$::env(PWD)/payloads/notevil.sh" -t chef -f "$::env(PWD)/payloads/chef-linux"
+
+expect "Is your target a chef workstation?\[Y/n/q\]"
+send "Y\r"
+expect eof


### PR DESCRIPTION
- Create expect script for chef workstation testing
- Add logic to test file upload payload against chef workstation (closes #35)
- Add logic to test file upload payload against puppet master (closes #39)
- Run `go mod tidy`
- Run `gofmt -w -s `on previously missed files
- Add comments to exported functions
- Update copyright date on all files to 2020