### PR TITLE
build: update CI workflows to Go 1.25.6 and add Taskfile for unified automation

### DIFF
--- a/.github/workflows/build-warpgate-image.yaml
+++ b/.github/workflows/build-warpgate-image.yaml
@@ -39,7 +39,7 @@ concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
 
 env:
-  GO_VERSION: "1.25.5"
+  GO_VERSION: "1.25.6"
   TASK_VERSION: "3.38.0"
   TASK_X_REMOTE_TASKFILES: 1
 

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -6,7 +6,7 @@ on:
       - "*"
 
 env:
-  GO_VERSION: 1.25.5
+  GO_VERSION: 1.25.6
 
 jobs:
   goreleaser:

--- a/.github/workflows/pipeline-mose.yaml
+++ b/.github/workflows/pipeline-mose.yaml
@@ -37,8 +37,8 @@ jobs:
           GO111MODULE: on
           GOBIN: ${{ github.workspace }}/bin
         run: |
-          go get github.com/markbates/pkger/cmd/pkger
-          go get -u -v
+          go install github.com/markbates/pkger/cmd/pkger@v0.17.1
+          go mod download
           go build
           mkdir -p payloads
 

--- a/.github/workflows/pipeline-mose.yaml
+++ b/.github/workflows/pipeline-mose.yaml
@@ -4,26 +4,34 @@ name: MOSE Build and Test
 on:
   push:
     branches:
-      - master
+      - main
   schedule:
     - cron: "0 0 * * 0"
   workflow_dispatch:
 
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 permissions:
   contents: read
+
+env:
+  DEBIAN_FRONTEND: noninteractive
+  GO_VERSION: 1.25.6
 
 jobs:
   build-test:
     runs-on: ubuntu-24.04
-
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         with:
-          go-version-file: go.mod
+          go-version: ${{ env.GO_VERSION }}
+          check-latest: true
 
       - name: Add GOBIN to PATH
         env:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -23,7 +23,7 @@ concurrency:
 
 env:
   DEBIAN_FRONTEND: noninteractive
-  GO_VERSION: 1.25.5
+  GO_VERSION: 1.25.6
   PYTHON_VERSION: 3.13.3
   TASK_VERSION: 3.45.5
   TASK_X_REMOTE_TASKFILES: 1

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -34,7 +34,7 @@ concurrency:
 
 # Retrieve BOT_USER_ID via `curl -s "https://api.github.com/users/${BOT_USERNAME}%5Bbot%5D" | jq .id`
 env:
-  GO_VERSION: 1.25.5
+  GO_VERSION: 1.25.6
   PYTHON_VERSION: 3.13.3
   RENOVATE_GIT_AUTHOR: "${{ secrets.BOT_USERNAME }} <${{ secrets.BOT_USER_ID }}+${{ secrets.BOT_USERNAME }}[bot]@users.noreply.github.com>"
 

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -34,6 +34,10 @@ jobs:
       - name: Generate Token
         uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         id: app-token
+        env:
+          BOT_APP_ID: ${{ secrets.BOT_APP_ID }}
+          BOT_APP_PRIVATE_KEY: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+        if: ${{ env.BOT_APP_ID != '' && env.BOT_APP_PRIVATE_KEY != '' }}
         with:
           app-id: "${{ secrets.BOT_APP_ID }}"
           private-key: "${{ secrets.BOT_APP_PRIVATE_KEY }}"
@@ -41,7 +45,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          token: "${{ steps.app-token.outputs.token }}"
+          token: "${{ steps.app-token.outputs.token || github.token }}"
 
       - name: Run Semgrep analysis
         uses: returntocorp/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d # v1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,7 +20,7 @@ concurrency:
 
 env:
   DEBIAN_FRONTEND: noninteractive
-  GO_VERSION: 1.25.5
+  GO_VERSION: 1.25.6
   TASK_VERSION: 3.45.5
   TASK_X_REMOTE_TASKFILES: 1
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,0 +1,141 @@
+---
+# yaml-language-server: $schema=https://taskfile.dev/schema.json
+version: "3"
+
+vars:
+  BINARY_NAME: mose
+  CMD_PATH: ./cmd/mose
+
+includes:
+  go:
+    taskfile: "https://raw.githubusercontent.com/CowDogMoo/taskfile-templates/main/go/Taskfile.yaml"
+    vars:
+      BINARY_NAME: mose
+      CMD_PATH: ./cmd/mose
+  docker:
+    taskfile: "https://raw.githubusercontent.com/CowDogMoo/taskfile-templates/main/docker/Taskfile.yaml"
+  github:
+    taskfile: "https://raw.githubusercontent.com/CowDogMoo/taskfile-templates/main/github/Taskfile.yaml"
+  pre-commit:
+    taskfile: "https://raw.githubusercontent.com/CowDogMoo/taskfile-templates/main/pre-commit/Taskfile.yaml"
+  secrets:
+    taskfile: "https://raw.githubusercontent.com/CowDogMoo/taskfile-templates/main/secrets/Taskfile.yaml"
+  renovate:
+    taskfile: "https://raw.githubusercontent.com/CowDogMoo/taskfile-templates/main/renovate/Taskfile.yaml"
+
+tasks:
+  default:
+    desc: Build, test, and clean
+    cmds:
+      - task: go:default
+
+  schema:generate:
+    desc: Placeholder schema generator (mose does not ship a JSON schema yet)
+    cmds:
+      - echo "No schema generator configured for mose."
+
+  schema:validate:
+    desc: Placeholder schema validation (mose does not ship a JSON schema yet)
+    cmds:
+      - echo "No schema validation configured for mose."
+
+  images:discover:
+    desc: Discover all container images with docker-bake.hcl files
+    silent: true
+    cmds:
+      - |
+        echo "Discovering container images..."
+        find dockerfiles -mindepth 1 -maxdepth 1 -type d -exec test -f {}/docker-bake.hcl \; -exec basename {} \;
+
+  images:build:
+    desc: "Build a specific container image (usage: task images:build IMAGE=mose)"
+    vars:
+      IMAGE: '{{.IMAGE | default ""}}'
+      PLATFORMS: '{{.PLATFORMS | default "linux/amd64,linux/arm64"}}'
+      PUSH: '{{.PUSH | default "false"}}'
+    preconditions:
+      - sh: test -n "{{.IMAGE}}"
+        msg: "IMAGE variable is required. Usage - task images:build IMAGE=mose"
+      - sh: test -f "dockerfiles/{{.IMAGE}}/docker-bake.hcl"
+        msg: "docker-bake.hcl not found for image {{.IMAGE}}"
+    cmds:
+      - |
+        echo "Building container image: {{.IMAGE}}"
+        echo "Platforms: {{.PLATFORMS}}"
+        echo "Push: {{.PUSH}}"
+
+        # Ensure buildx builder exists and is active
+        docker buildx inspect multiarch-builder 2>/dev/null || \
+          docker buildx create --name multiarch-builder --bootstrap --use --driver docker-container
+        docker buildx use multiarch-builder
+
+        # Build using docker bake
+        if [ "{{.PUSH}}" = "true" ]; then
+          # Push to registry
+          docker buildx bake \
+            --file ./dockerfiles/{{.IMAGE}}/docker-bake.hcl \
+            --set "*.platform={{.PLATFORMS}}" \
+            --set "*.output=type=registry,push=true" \
+            multi
+        else
+          # Build locally without push (multi-platform images stay in build cache)
+          docker buildx bake \
+            --file ./dockerfiles/{{.IMAGE}}/docker-bake.hcl \
+            --set "*.platform={{.PLATFORMS}}" \
+            --set "*.output=type=image,push=false" \
+            multi
+        fi
+
+  images:build-all:
+    desc: "Build all container images (use PUSH=true to push to registry)"
+    vars:
+      PLATFORMS: '{{.PLATFORMS | default "linux/amd64,linux/arm64"}}'
+      PUSH: '{{.PUSH | default "false"}}'
+    cmds:
+      - |
+        echo "Discovering and building all container images..."
+        echo "Platforms: {{.PLATFORMS}}"
+        echo "Push: {{.PUSH}}"
+        echo ""
+
+        IMAGES=$(find dockerfiles -mindepth 1 -maxdepth 1 -type d -exec test -f {}/docker-bake.hcl \; -exec basename {} \;)
+
+        for image in $IMAGES; do
+          echo "========================================="
+          echo "Building: $image"
+          echo "========================================="
+          task images:build IMAGE=$image PLATFORMS={{.PLATFORMS}} PUSH={{.PUSH}}
+          echo ""
+        done
+
+        echo "✅ All images built successfully!"
+
+  images:load:
+    desc: "Build and load a container image locally (single platform)"
+    vars:
+      IMAGE: '{{.IMAGE | default ""}}'
+      PLATFORM: '{{.PLATFORM | default "linux/amd64"}}'
+    preconditions:
+      - sh: test -n "{{.IMAGE}}"
+        msg: "IMAGE variable is required. Usage - task images:load IMAGE=mose"
+      - sh: test -f "dockerfiles/{{.IMAGE}}/docker-bake.hcl"
+        msg: "docker-bake.hcl not found for image: {{.IMAGE}}"
+    cmds:
+      - |
+        echo "Building and loading container image: {{.IMAGE}}"
+        echo "Platform: {{.PLATFORM}}"
+
+        # Determine which target to use based on platform
+        if echo "{{.PLATFORM}}" | grep -q "arm64"; then
+          TARGET="arm64"
+        else
+          TARGET="amd64"
+        fi
+
+        echo "Target: $TARGET"
+
+        docker buildx bake \
+          --file ./dockerfiles/{{.IMAGE}}/docker-bake.hcl \
+          --set "${TARGET}.tags={{.IMAGE}}:latest" \
+          --load \
+          ${TARGET}


### PR DESCRIPTION

**Key Changes:**

- Updated all GitHub Actions workflows to use Go version 1.25.6 for consistency and security
- Introduced a new `Taskfile.yaml` with tasks for build, test, and Docker image automation
- Improved CI pipeline with locked action versions and enhanced platform/image build logic
- Enhanced security and reproducibility by pinning action SHAs and tightening workflow configs

**Added:**

- Unified `Taskfile.yaml` providing tasks for Go builds, Docker images, schema stubs, and image management, including multi-platform support and registry push/load logic

**Changed:**

- Upgraded `GO_VERSION` from 1.25.5 to 1.25.6 in all relevant workflows for bugfixes and security updates
- Switched default branch in `pipeline-mose.yaml` from `master` to `main` for alignment with repo standards
- Added workflow concurrency settings and `DEBIAN_FRONTEND` environment variable to `pipeline-mose.yaml` for more predictable and efficient runs
- Updated `actions/checkout` and `actions/setup-go` to pinned SHAs in multiple workflows for improved supply chain security
- Improved `pipeline-mose.yaml` build steps: replaced `go get` with `go install` for deterministic tool installation, and used `go mod download` for dependency management
- Enhanced `semgrep.yaml` to conditionally set environment variables for app token generation and to use a fallback token for checkout if app token is unavailable
- Set `GO_VERSION` environment variable to 1.25.6 in `pre-commit.yaml`, `renovate.yaml`, and `tests.yaml` for environment consistency